### PR TITLE
[feat] 쿠키 기능 1차 구현

### DIFF
--- a/getpdf
+++ b/getpdf
@@ -1,0 +1,3 @@
+GET /sample.pdf HTTP/1.1
+host: localhost
+

--- a/inc/define.hpp
+++ b/inc/define.hpp
@@ -22,14 +22,16 @@ static const std::string HEAD[] =
 {
 	"transfer-encoding",
 	"content-length",
-	"connection"
+	"connection",
+	"cookie"
 };
 
 enum eHeader
 {
 	TRANSFER_ENCODING,
 	CONTENT_LENGTH,
-	CONNECTION
+	CONNECTION,
+	COOKIE
 };
 
 

--- a/inc/request/Request.hpp
+++ b/inc/request/Request.hpp
@@ -6,6 +6,7 @@
 # include "../parse/Config.hpp"
 # include "../parse/Util.hpp"
 # include "../response/Cgi.hpp"
+# include "Session.hpp"
 
 using std::string;
 using std::cout;
@@ -41,6 +42,9 @@ struct Request
 	std::string					tmp;
 
 	string virtualPath;
+
+	std::map<string, string> cookies;
+	Session session;
 
 	int maxBodySize;
 	int readSize;
@@ -108,10 +112,23 @@ struct Request
 			fileName = g_conf[configName][locationName]["index"].front();
 		ext = findExtension(fileName);
 
+		if (Header.count(HEAD[COOKIE]))
+			get_cookie();
+
 		if (Header.count(HEAD[CONTENT_LENGTH]))
 			contentLength = Util::stoi(Header[HEAD[CONTENT_LENGTH]]);
 		if (Header.count(HEAD[TRANSFER_ENCODING]))
 			chunkFlag = true;
+	}
+
+	void get_cookie()
+	{
+		vector<string> splited = Util::split(Header[HEAD[COOKIE]], ';');
+		for (std::vector<string>::iterator it = splited.begin(); it != splited.end(); ++it)
+		{
+			vector<string> tmp = Util::split(*it, '=');
+			cookies[tmp[0]] = tmp[1];
+		}
 	}
 
 	int parse()

--- a/inc/request/Session.hpp
+++ b/inc/request/Session.hpp
@@ -1,0 +1,38 @@
+#ifndef SESSION_HPP
+# define SESSION_HPP
+
+#include <map>
+#include <string>
+#include <vector>
+
+struct Session
+{
+	// 리퀘스트 헤더에서 쿠키를 저장한다
+    // 해당 쿠키를 키로 해서 값을 찾고, 헤더에 없거나 해당 키로 세션을 찾지못하면 랜덤값 생성해서 set-cookie 로 담기
+    // cgi 실행시 세션의 값을 환경변수에 담아서 전달
+    // TODO:클라에서 넘어온 값을 해당 세션에 저장
+    // cookie.php을 이용해서 검색기록 구현
+
+	std::map<std::string, std::vector<std::string>> Session;
+ 
+	std::string gen_random(const int len) const
+	{
+		static const char alphanum[] =
+			"0123456789"
+			"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+			"abcdefghijklmnopqrstuvwxyz";
+		std::string tmp;
+		tmp.reserve(len);
+
+		for (int i = 0; i < len; ++i) 
+		{
+			tmp += alphanum[rand() % (sizeof(alphanum) - 1)];
+		}
+
+		return tmp;
+	}
+};
+
+
+
+#endif

--- a/inc/response/Response.hpp
+++ b/inc/response/Response.hpp
@@ -25,7 +25,7 @@ struct ResponseStartLine
 
 struct Response
 {
-	const Request *Req;
+	Request *Req;
 	ResponseStartLine StartLine;
 	map<string, string> Header;
 	string Body;
@@ -190,7 +190,26 @@ int 	Response::execute()
 			throw 400;
 
 		if (g_conf[Req->configName][Req->locationName].is_exist(ext))
+		{
+			if (Req->cookies.count(ext) == 0)
+			{
+				Header["set-cookie"] = ext + "=" + Req->session.gen_random(12) + ";";
+			}
+			else
+			{
+				string tmp;
+				for (std::vector<string>::iterator it = Req->session.Session[Req->cookies[ext]].begin(); it != Req->session.Session[Req->cookies[ext]].end(); ++it)
+					tmp += *it + ":";
+				if (!tmp.empty())
+				{
+					tmp.insert(0, "COOKIE=");	
+					tmp.erase(tmp.size() - 1);
+					params.push_back(tmp);
+				}
+			}
+
 			contentResult = new Cgi(path, ext, params);
+		}
 		else
 			contentResult = new File(path);
 

--- a/inc/response/Response.hpp
+++ b/inc/response/Response.hpp
@@ -207,6 +207,9 @@ int 	Response::execute()
 					params.push_back(tmp);
 				}
 			}
+			if (Req->StartLine.method == "POST")
+				Req->session.Session[Req->cookies[ext]].push_back(Req->bodySS.str());
+
 
 			contentResult = new Cgi(path, ext, params);
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,8 @@ int main(int argc, char** argv)
 		return 1;
 	}
 	Event event;
-		
+	
+	srand((unsigned)time(NULL) * getpid());
 	event.event_loop();
 	// system("leaks miniNginx");
     return 0;

--- a/www/cookie.php
+++ b/www/cookie.php
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="ko">
+ <head>
+  <meta charset="UTF-8">
+  <title>로그인</title>
+</head>
+<body>
+    <form method="post">
+    <p>검색내용 : <input type="text" name="검색내용"></p>
+    <p><input type="submit" value="검색"></p>
+    </form>
+<?php
+    if (getenv('COOKIE'))
+    {
+        echo getenv('COOKIE');
+    }
+    print($_POST['검색내용']);  
+?>
+</body>
+</html>

--- a/www/sample.pdf
+++ b/www/sample.pdf
@@ -1,0 +1,198 @@
+%PDF-1.3
+%‚„œ”
+
+1 0 obj
+<<
+/Type /Catalog
+/Outlines 2 0 R
+/Pages 3 0 R
+>>
+endobj
+
+2 0 obj
+<<
+/Type /Outlines
+/Count 0
+>>
+endobj
+
+3 0 obj
+<<
+/Type /Pages
+/Count 2
+/Kids [ 4 0 R 6 0 R ] 
+>>
+endobj
+
+4 0 obj
+<<
+/Type /Page
+/Parent 3 0 R
+/Resources <<
+/Font <<
+/F1 9 0 R 
+>>
+/ProcSet 8 0 R
+>>
+/MediaBox [0 0 612.0000 792.0000]
+/Contents 5 0 R
+>>
+endobj
+
+5 0 obj
+<< /Length 1074 >>
+stream
+2 J
+BT
+0 0 0 rg
+/F1 0027 Tf
+57.3750 722.2800 Td
+( A Simple PDF File ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 688.6080 Td
+( This is a small demonstration .pdf file - ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 664.7040 Td
+( just for use in the Virtual Mechanics tutorials. More text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 652.7520 Td
+( text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 628.8480 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 616.8960 Td
+( text. And more text. Boring, zzzzz. And more text. And more text. And ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 604.9440 Td
+( more text. And more text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 592.9920 Td
+( And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 569.0880 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 557.1360 Td
+( text. And more text. And more text. Even more. Continued on page 2 ...) Tj
+ET
+endstream
+endobj
+
+6 0 obj
+<<
+/Type /Page
+/Parent 3 0 R
+/Resources <<
+/Font <<
+/F1 9 0 R 
+>>
+/ProcSet 8 0 R
+>>
+/MediaBox [0 0 612.0000 792.0000]
+/Contents 7 0 R
+>>
+endobj
+
+7 0 obj
+<< /Length 676 >>
+stream
+2 J
+BT
+0 0 0 rg
+/F1 0027 Tf
+57.3750 722.2800 Td
+( Simple PDF File 2 ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 688.6080 Td
+( ...continued from page 1. Yet more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 676.6560 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 664.7040 Td
+( text. Oh, how boring typing this stuff. But not as boring as watching ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 652.7520 Td
+( paint dry. And more text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 640.8000 Td
+( Boring.  More, a little more text. The end, and just as well. ) Tj
+ET
+endstream
+endobj
+
+8 0 obj
+[/PDF /Text]
+endobj
+
+9 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/Name /F1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+
+10 0 obj
+<<
+/Creator (Rave \(http://www.nevrona.com/rave\))
+/Producer (Nevrona Designs)
+/CreationDate (D:20060301072826)
+>>
+endobj
+
+xref
+0 11
+0000000000 65535 f
+0000000019 00000 n
+0000000093 00000 n
+0000000147 00000 n
+0000000222 00000 n
+0000000390 00000 n
+0000001522 00000 n
+0000001690 00000 n
+0000002423 00000 n
+0000002456 00000 n
+0000002574 00000 n
+
+trailer
+<<
+/Size 11
+/Root 1 0 R
+/Info 10 0 R
+>>
+
+startxref
+2714
+%%EOF

--- a/www/upload.html
+++ b/www/upload.html
@@ -1,0 +1,9 @@
+<form method="post" enctype="multipart/form-data">
+    <div>
+      <label for="file">Choose file to upload</label>
+      <input type="file" id="file" name="file" multiple>
+    </div>
+    <div>
+      <button>Submit</button>
+    </div>
+   </form>


### PR DESCRIPTION
장고끝에 악수둔다고 두번 엎었는데 마음에는 안듭니다. 사실상 cookie.php처럼 쿠키가 리스트 형태로 사용될때에만 정상적으로 동작하도록 만들어졌는데, 이게 맞나 싶네요. 

php가 쿠키를 지울때 서버에서 그걸 알 방법이 있으면 로그인도 동시에 가능할것같은데, 현재에는 로그인과 리스트 둘중에 하나만 선택해서 구현할수있습니다. 이건 바꾸는게 어렵지않아서 나중에 평가자에게 설명하기 쉬운 방법으로 선택하면 될것같습니다.


구현 내용은 post로 cgi 호출시 확장자별로 다른 랜덤값을 부여해서 그걸 set-cookie로 담아서 클라이언트에 넘겨주고,

해당 랜덤값을 세션 구조체의 맵에 담아서 보관한다음 이후에 다시 호출될때 그 내부 값을 꺼내서 출력하는 방식으로 구현했습니다. 

리퀘스트와 리스폰스의 기존 변수를 최대한 안건들고 짜려고하다보니 코드가 지저분한데 이건 동작하는거 보고 다시 고치겠습니다. 

컴파일 문제는 리스폰스의 Req에 붙은 const 를 잠시 지워서 그렇습니다. 이것도 기존 변수여서 일단 뒀습니다.  


테스트는 아직 안되는데 Session 구조체가 Event로 올라가면 리퀘스트에 어떻게 전달해야할지를 못정했습니다... 아마 테스트를 하면 리퀘스트가 delete될때 세션이 같이 없어지는 문제가 있을것 같습니다.